### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/lib.rs"
 
 git = "https://github.com/iron/iron.git"
 
-[dependencies.rust-http]
+[dependencies.http]
 
 git = "https://github.com/chris-morgan/rust-http.git"
 


### PR DESCRIPTION
Switch back to Chris Morgan's Rust HTTP now that cargo is supported there
