### PR TITLE
route now takes the method in consideration

### DIFF
--- a/src/router/mod.rs
+++ b/src/router/mod.rs
@@ -80,7 +80,7 @@ impl Middleware for Router {
         };
 
         for route in self.routes.mut_iter() {
-            if route.matches.is_match(request_uri.as_slice()) {
+            if route.method == req.method && route.matches.is_match(request_uri.as_slice()) {
                 alloy.insert::<params::Params>(
                     params::Params::new(
                         request_uri.as_slice(),


### PR DESCRIPTION
Hi,

In others frameworks (Play for example) we can use the same URI with different methods (GET and POST for example).

I made a little test program to try this in iron: http://pastebin.com/GRtmtk9T
By executing it I get the following results:

```
 $ curl -X POST http://localhost:3000/method
 POST
 $ curl -X GET http://localhost:3000/method
 POST
```

As can be seen, both POST and GET gets mapped to the same handler.

I'm creating a pull request that adds an extra method comparison to determine which handler to execute. (I'm a rust and iron newbie).
