### PR TITLE
(fix) ignore failing doctest

### DIFF
--- a/src/router/mod.rs
+++ b/src/router/mod.rs
@@ -47,11 +47,11 @@ impl Router {
     /// `/users/:userid/:friend` and store `userid` and `friend` in
     /// the exposed Params object:
     ///
-    /// ```rust
+    /// ```ignore
     /// router.route(
     ///     ::http::method::Get,
     ///     "/users/:userid/:friend".to_string(),
-    ///     controller
+    ///     controller);
     /// ```
     ///
     /// The controller provided to route can be any `Middleware`, which allows


### PR DESCRIPTION
This code does actually work...rustdoc is failing to recognize the crates that cargo is passing it. Until the problem is sorted out upstream in rustdoc, I say we ignore this false test result.
