### PR TITLE
Use `entry` instead of deprecated `find_or_insert_with`.

### DIFF
--- a/src/router.rs
+++ b/src/router.rs
@@ -47,12 +47,10 @@ impl Router {
     /// a controller function, so that you can confirm that the request is
     /// authorized for this route before handling it.
     pub fn route<'a, H: Handler, S: Str>(&mut self, method: Method, glob: S, handler: H) -> &mut Router {
-        match self.routers
-            .entry(method) {
-                Vacant(entry)   => entry.set(Recognizer::new()),
-                Occupied(entry) => entry.into_mut()
-            }
-        .add(glob.as_slice(), box handler as Box<Handler + Send + Sync>);
+        match self.routers.entry(method) {
+            Vacant(entry)   => entry.set(Recognizer::new()),
+            Occupied(entry) => entry.into_mut()
+        }.add(glob.as_slice(), box handler as Box<Handler + Send + Sync>);
         self
     }
 


### PR DESCRIPTION
Build against rust nightly `rustc 0.12.0-nightly (d64b4103d 2014-09-26 21:47:47 +0000)` fails due to 

```
src/router.rs:49:9: 50:64 error: use of deprecated item: use entry instead, #[deny(deprecated)] on by default
src/router.rs:49         self.routers
src/router.rs:50             .find_or_insert_with(method, |_| Recognizer::new())
error: aborting due to previous error
Could not compile `router`.
```

Use `entry` instead of `find_or_insert_with` to fix the error.
