### PR TITLE
Support trailing shashes in URLs

### DIFF
--- a/src/router.rs
+++ b/src/router.rs
@@ -51,7 +51,7 @@ impl Router {
         match self.routers.entry(method) {
             Vacant(entry)   => entry.set(Recognizer::new()),
             Occupied(entry) => entry.into_mut()
-        }.add(glob.as_slice(), box handler as Box<Handler + Send + Sync>);
+        }.add(glob.as_slice().trim_right_chars('/'), box handler as Box<Handler + Send + Sync>);
         self
     }
 
@@ -106,7 +106,7 @@ impl Assoc<Params> for Router {}
 
 impl Handler for Router {
     fn call(&self, req: &mut Request) -> IronResult<Response> {
-        let matched = match self.recognize(&req.method, req.url.path.connect("/").as_slice()) {
+        let matched = match self.recognize(&req.method, req.url.path.connect("/").as_slice().trim_right_chars('/')) {
             Some(matched) => matched,
             // No match.
             None => return Err(box NoRoute as IronError)


### PR DESCRIPTION
Suppose you have defined a route:

    router.get("/hello/:name", Server::hello);

I'd like to be able to access it with both URLs:

    http://localhost/hello/world
    http://localhost/hello/world/

However, currently the latter one gives me 500 Internal Server Error.

I know sometimes people implement 301 permanent redirect for a route with slash, sometimes create a parameter to control whether URL with trailing slash should be treated differently than the one without slash.

For the sake of simplicity, as you can see in this pull request, I propose just to ignore the trailing slash, and treat both URLs as valid for the registered handler.
If this becomes an important scenario, we could revisit it later on.