### PR TITLE
Compatibility with nightly Rust and Iron 0.0.10 fixes

### DIFF
--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -6,7 +6,6 @@ extern crate router;
 
 use iron::{Iron, Request, Response, IronResult, Set};
 use iron::status;
-use iron::response::modifiers::{Status, Body};
 use router::{Router, Params};
 
 fn main() {
@@ -18,6 +17,6 @@ fn main() {
 
     fn handler(req: &mut Request) -> IronResult<Response> {
         let ref query = req.extensions.get::<Router, Params>().unwrap().find("query").unwrap_or("/");
-        Ok(Response::new().set(Status(status::Ok)).set(Body(*query)))
+        Ok(Response::new().set(status::Ok).set(*query))
     }
 }

--- a/src/router.rs
+++ b/src/router.rs
@@ -1,9 +1,8 @@
 use std::collections::HashMap;
-use std::collections::hash_map::{Occupied, Vacant};
+use std::collections::hash_map::Entry;
 use std::error::Error;
 use iron::{Request, Response, Handler, IronResult, IronError, Set};
 use iron::{status, method};
-use iron::response::modifiers::Status;
 use iron::typemap::Assoc;
 use recognizer::Router as Recognizer;
 use recognizer::{Match, Params};
@@ -48,8 +47,8 @@ impl Router {
     /// authorized for this route before handling it.
     pub fn route<H: Handler, S: Str>(&mut self, method: method::Method, glob: S, handler: H) -> &mut Router {
         match self.routers.entry(method) {
-            Vacant(entry)   => entry.set(Recognizer::new()),
-            Occupied(entry) => entry.into_mut()
+            Entry::Vacant(entry)   => entry.set(Recognizer::new()),
+            Entry::Occupied(entry) => entry.into_mut()
         }.add(glob.as_slice(), box handler as Box<Handler + Send + Sync>);
         self
     }
@@ -119,7 +118,7 @@ impl Handler for Router {
         match self.error {
             Some(ref error_handler) => error_handler.catch(req, err),
             // Error that is not caught by anything!
-            None => (Response::new().set(Status(status::InternalServerError)), Err(err))
+            None => (Response::new().set(status::InternalServerError), Err(err))
         }
     }
 }


### PR DESCRIPTION
- "error: unresolved import `std::collections::hash_map::Occupied`" fix
- Compatibility with Iron 0.0.10 fix

I've just tried it with fresh nightly Rust build. Builds and runs the example fine.

Hope this helps.
