### PR TITLE
(fix) Fix for Rust alpha and latest Iron

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ fn main() {
     Iron::new(router).listen(Ipv4Addr(127, 0, 0, 1), 3000);
 
     fn handler(req: &mut Request) -> IronResult<Response> {
-        let ref query = req.extensions.find::<Router, Params>().unwrap().find("query").unwrap_or("/");
+        let ref query = req.extensions.find::<Router>().unwrap().find("query").unwrap_or("/");
         Ok(Response::with(status::Ok, *query))
     }
 }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -4,9 +4,9 @@ extern crate router;
 // To build, $ cargo test
 // To use, go to http://127.0.0.1:3000/test
 
-use iron::{Iron, Request, Response, IronResult, Set};
+use iron::{Iron, Request, Response, IronResult};
 use iron::status;
-use router::{Router, Params};
+use router::{Router};
 
 fn main() {
     let mut router = Router::new();
@@ -16,7 +16,7 @@ fn main() {
     Iron::new(router).listen("localhost:3000").unwrap();
 
     fn handler(req: &mut Request) -> IronResult<Response> {
-        let ref query = req.extensions.get::<Router, Params>()
+        let ref query = req.extensions.get::<Router>()
             .unwrap().find("query").unwrap_or("/");
         Ok(Response::with((status::Ok, *query)))
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 #![deny(missing_docs, warnings)]
-#![feature(phase, globs)]
+#![allow(unstable)]
 
 //! `Router` provides a fast router handler for the Iron web framework.
 


### PR DESCRIPTION
This pr fixes router for Rust alpha and Assoc changes. Unfortunately tests still won't pass because of 
https://github.com/rust-lang/rust/issues/20676

```
 internal compiler error: static call to invalid vtable: VtableObject(VtableObject(object_ty=error::Error + 'static))
```