### PR TITLE
Change installation instructions to use release

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ Router is a part of Iron's [core bundle](https://github.com/iron/core).
 If you're using cargo, just add router to your `Cargo.toml`.
 
 ```toml
-[dependencies.router]
+[dependencies]
 
-git = "https://github.com/iron/router.git"
+router = "*"
 ```
 
 Otherwise, `cargo build`, and the rlib will be in your `target` directory.


### PR DESCRIPTION
Installation instructions should recommend installing the latest release published to crates.io, not the master branch.