### PR TITLE
(release) 0.0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 name = "router"
 authors = ["Jonathan Reem <jonathan.reem@gmail.com>"]
 license = "MIT"
-version = "0.0.8"
+version = "0.0.9"
 description = "A router for the Iron framework."
 repository = "https://github.com/iron/router"
 documentation = "http://ironframework.io/doc/router/index.html"


### PR DESCRIPTION
The newly released fix for the overflow of trait bounds is necessary to use this crate but it's not possible to update via crates.io since it still is left at the old release of 0.0.8.