### PR TITLE
(feat) router! macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ to be any Handler, including all Chains.
 
 ```rust
 fn main() {
-    let mut router = Router::new();
-    router.get("/", handler);
-    router.get("/:query", handler);
+    let mut router = Router::new();  // Alternative syntax:
+    router.get("/", handler);        // let router = router!(get "/" => handler,
+    router.get("/:query", handler);  //                      get "/:query" => handler);
 
-    Iron::new(router).listen(Ipv4Addr(127, 0, 0, 1), 3000);
+    Iron::new(router).http("localhost:3000").unwrap();
 
     fn handler(req: &mut Request) -> IronResult<Response> {
         let ref query = req.extensions.get::<Router>().unwrap().find("query").unwrap_or("/");

--- a/examples/simple_with_macro.rs
+++ b/examples/simple_with_macro.rs
@@ -1,0 +1,22 @@
+extern crate iron;
+#[macro_use]
+extern crate router;
+
+// To build, $ cargo test
+// To use, go to http://127.0.0.1:3000/test
+
+use iron::{Iron, Request, Response, IronResult};
+use iron::status;
+use router::{Router};
+
+fn main() {
+    let router = router!(get "/" => handler, get "/:query" => handler);
+
+    Iron::new(router).http("localhost:3000").unwrap();
+
+    fn handler(req: &mut Request) -> IronResult<Response> {
+        let ref query = req.extensions.get::<Router>()
+            .unwrap().find("query").unwrap_or("/");
+        Ok(Response::with((status::Ok, *query)))
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,5 +10,4 @@ pub use router::Router;
 pub use recognizer::Params;
 
 mod router;
-
-
+mod macros;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,47 @@
+/// Create and populate a router.
+///
+/// ```ignore
+/// let router = router!(get  "/"       => index,
+///                      get  "/:query" => queryHandler,
+///                      post "/"       => postHandler);
+/// ```
+///
+/// Is equivalent to:
+///
+/// ```ignore
+///    let mut router = Router::new();
+///    router.get("/", index);
+///    router.get("/:query", queryHandler);
+///    router.post("/", postHandler);
+/// ```
+///
+/// The method name must be lowercase, supported methods:
+///
+/// `get`, `post`, `put`, `delete`, `head`, `patch`, `options`.
+#[macro_export]
+macro_rules! router {
+    ($($method:ident $glob:expr => $handler:expr),+) => ({
+        let mut router = Router::new();
+        $(router.$method($glob, $handler);)*
+        router
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use router::Router;
+    use iron::{Response, Request, IronResult};
+
+    //simple test to check that all methods expand without error
+    #[test]
+    fn methods() {
+        fn handler(_: &mut Request) -> IronResult<Response> {Ok(Response::new())}
+        let _ = router!(get     "/foo" => handler,
+                        post    "/bar/" => handler,
+                        put     "/bar/baz" => handler,
+                        delete  "/bar/baz" => handler,
+                        head    "/foo" => handler,
+                        patch   "/bar/baz" => handler,
+                        options "/foo" => handler);
+    }
+}


### PR DESCRIPTION
Implements a `router!` macro as in #48, with docs and an example. Now it's just sugar for features that already exist, I hope it's flexible enough to accommodate fancier features such as overlap checking. I simplified the syntax slightly by removing the colon, `get "/route" => handler` instead of `get: "/route" => handler`.