### PR TITLE
have Router impl plugin::Plugin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,5 @@ keywords = ["iron", "web", "http", "routing", "router"]
 [dependencies]
 iron = "0.1"
 route-recognizer = "0.1"
+plugin = "0.2"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@
 
 extern crate iron;
 extern crate route_recognizer as recognizer;
+extern crate plugin;
 
 pub use router::Router;
 pub use recognizer::Params;

--- a/src/router.rs
+++ b/src/router.rs
@@ -13,6 +13,8 @@ use iron::modifiers::Redirect;
 use recognizer::Router as Recognizer;
 use recognizer::{Match, Params};
 
+use super::plugin;
+
 /// `Router` provides an interface for creating complex routes as middleware
 /// for the Iron framework.
 pub struct Router {
@@ -156,6 +158,17 @@ impl Router {
 }
 
 impl Key for Router { type Value = Params; }
+
+impl<'a, 'b> plugin::Plugin<Request<'a, 'b>> for Router {
+    type Error = ();
+
+    fn eval(req: &mut Request) -> Result<Params, ()> {
+        match req.extensions.get::<Router>() {
+            Some(params) => Ok(params.clone()),
+            None         => Err(()),
+        }
+    }
+}
 
 impl Handler for Router {
     fn handle(&self, req: &mut Request) -> IronResult<Response> {


### PR DESCRIPTION
This way you can access URL parameters the same way as GET/POST parameters, using `req.get_ref` and not `req.extensions.get` (which is unreliable due to laziness).