### PR TITLE
(fix) Allow trailing comma in router!

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -20,7 +20,7 @@
 /// `get`, `post`, `put`, `delete`, `head`, `patch`, `options`.
 #[macro_export]
 macro_rules! router {
-    ($($method:ident $glob:expr => $handler:expr),+) => ({
+    ($($method:ident $glob:expr => $handler:expr),+ $(,)*) => ({
         let mut router = $crate::Router::new();
         $(router.$method($glob, $handler);)*
         router
@@ -41,6 +41,6 @@ mod tests {
                         delete  "/bar/baz" => handler,
                         head    "/foo" => handler,
                         patch   "/bar/baz" => handler,
-                        options "/foo" => handler);
+                        options "/foo" => handler,);
     }
 }


### PR DESCRIPTION
Part of #48. Kudos to Daniel Keep's [The Little Book of Rust Macros](https://danielkeep.github.io/tlborm/) for teaching me this!