### PR TITLE
Rename connect to join and add any method to match any HTTP verb [Fixes #102]

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -17,7 +17,7 @@
 ///
 /// The method name must be lowercase, supported methods:
 ///
-/// `get`, `post`, `put`, `delete`, `head`, `patch`, `options`.
+/// `get`, `post`, `put`, `delete`, `head`, `patch`, `options` and `any`.
 #[macro_export]
 macro_rules! router {
     ($($method:ident $glob:expr => $handler:expr),+ $(,)*) => ({
@@ -41,6 +41,7 @@ mod tests {
                         delete  "/bar/baz" => handler,
                         head    "/foo" => handler,
                         patch   "/bar/baz" => handler,
-                        options "/foo" => handler,);
+                        options "/foo" => handler,
+                        any     "/" => handler);
     }
 }

--- a/src/router.rs
+++ b/src/router.rs
@@ -1,6 +1,3 @@
-// FIXME(reem): When join makes it into stable, remove this and replace connect with join.
-#![allow(deprecated)]
-
 use std::collections::HashMap;
 use std::error::Error;
 use std::fmt;
@@ -129,7 +126,7 @@ impl Router {
     // Tests for a match by adding or removing a trailing slash.
     fn redirect_slash(&self, req : &Request) -> Option<IronError> {
         let mut url = req.url.clone();
-        let mut path = url.path.connect("/");
+        let mut path = url.path.join("/");
 
         if let Some(last_char) = path.chars().last() {
             if last_char == '/' {
@@ -159,7 +156,7 @@ impl Key for Router { type Value = Params; }
 
 impl Handler for Router {
     fn handle(&self, req: &mut Request) -> IronResult<Response> {
-        let path = req.url.path.connect("/");
+        let path = req.url.path.join("/");
 
         self.handle_method(req, &path).unwrap_or_else(||
             match req.method {


### PR DESCRIPTION
Use of  `connect` was renamed to `join`. An unrelated refactor was switching `"".to_string()` for `String::new()`.

The new `any` method will ignore the HTTP method, matching all requests sent to the URL. This fixes #102. To implement this a new field `wildcard : Recognizer<...>` was added. Documentation was updated to reflect the addition.