### PR TITLE
Standardize examples docs and add second Handler to demonstrate routing

### DIFF
--- a/examples/custom_404.rs
+++ b/examples/custom_404.rs
@@ -2,7 +2,8 @@ extern crate iron;
 extern crate router;
 
 // To run, $ cargo run --example custom_404
-// then go to http://localhost:3000 in a web browser
+// To use, go to http://localhost:3000/foobar to see the custom 404
+// Or, go to http://localhost:3000 for a standard 200 OK
 
 use iron::{Iron, Request, Response, IronResult, AfterMiddleware, Chain};
 use iron::error::{IronError};

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,8 +1,8 @@
 extern crate iron;
 extern crate router;
 
-// To build, $ cargo test
-// To use, go to http://127.0.0.1:3000/test
+// To run, $ cargo run --example simple
+// To use, go to http://localhost:3000/test and see output "test"
 
 use iron::{Iron, Request, Response, IronResult};
 use iron::status;

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -3,6 +3,7 @@ extern crate router;
 
 // To run, $ cargo run --example simple
 // To use, go to http://localhost:3000/test and see output "test"
+// Or, go to http://localhost:3000 to see a default "OK"
 
 use iron::{Iron, Request, Response, IronResult};
 use iron::status;
@@ -11,13 +12,19 @@ use router::{Router};
 fn main() {
     let mut router = Router::new();
     router.get("/", handler);
-    router.get("/:query", handler);
+    router.get("/:query", query_handler);
 
     Iron::new(router).http("localhost:3000").unwrap();
 
-    fn handler(req: &mut Request) -> IronResult<Response> {
+    fn handler(_: &mut Request) -> IronResult<Response> {
+        Ok(Response::with((status::Ok, "OK")))
+    }
+
+    fn query_handler(req: &mut Request) -> IronResult<Response> {
         let ref query = req.extensions.get::<Router>()
             .unwrap().find("query").unwrap_or("/");
         Ok(Response::with((status::Ok, *query)))
     }
+
+
 }

--- a/examples/simple_with_macro.rs
+++ b/examples/simple_with_macro.rs
@@ -4,17 +4,22 @@ extern crate router;
 
 // To run, $ cargo run --example simple_with_macro
 // To use, go to http://localhost:3000/test and see output "test"
+// Or, go to http://localhost:3000 to see a default "OK"
 
 use iron::{Iron, Request, Response, IronResult};
 use iron::status;
 use router::{Router};
 
 fn main() {
-    let router = router!(get "/" => handler, get "/:query" => handler);
+    let router = router!(get "/" => handler, get "/:query" => query_handler);
 
     Iron::new(router).http("localhost:3000").unwrap();
 
-    fn handler(req: &mut Request) -> IronResult<Response> {
+    fn handler(_: &mut Request) -> IronResult<Response> {
+        Ok(Response::with((status::Ok, "OK")))
+    }
+
+    fn query_handler(req: &mut Request) -> IronResult<Response> {
         let ref query = req.extensions.get::<Router>()
             .unwrap().find("query").unwrap_or("/");
         Ok(Response::with((status::Ok, *query)))

--- a/examples/simple_with_macro.rs
+++ b/examples/simple_with_macro.rs
@@ -2,8 +2,8 @@ extern crate iron;
 #[macro_use]
 extern crate router;
 
-// To build, $ cargo test
-// To use, go to http://127.0.0.1:3000/test
+// To run, $ cargo run --example simple_with_macro
+// To use, go to http://localhost:3000/test and see output "test"
 
 use iron::{Iron, Request, Response, IronResult};
 use iron::status;


### PR DESCRIPTION
The examples used different language to explain how to test, and testing with `127.0.0.1:3000` won't necessarily work (e.g. IPv6, localhost bound elsewhere), and the Iron Server is binding to `localhost` in all cases, so the wording was standardized and now all say `localhost`.

Changed the simple examples to have a second handler to show that in the event of going to `/` the router will properly go to a different route. I find this demonstration useful, what do you think?