### PR TITLE
Deriving PartialEq and Eq for routing errors.

### DIFF
--- a/src/router.rs
+++ b/src/router.rs
@@ -187,7 +187,7 @@ impl Handler for Router {
 
 /// The error thrown by router if there is no matching route,
 /// it is always accompanied by a NotFound response.
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct NoRoute;
 
 impl fmt::Display for NoRoute {
@@ -202,7 +202,7 @@ impl Error for NoRoute {
 
 /// The error thrown by router if a request was redirected
 /// by adding or removing a trailing slash.
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct TrailingSlash;
 
 impl fmt::Display for TrailingSlash {


### PR DESCRIPTION
While testing my application I realized I couldn't make assertions of kind `assert_eq!`, because these structs (particularly `NoRoute`) wasn't comparable. 😄 