### PR TITLE
(feat) Make compatible with Iron 0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,4 @@ keywords = ["iron", "web", "http", "routing", "router"]
 
 [dependencies]
 route-recognizer = "0.1"
-iron = "0.3"
+iron = "0.4"

--- a/src/router.rs
+++ b/src/router.rs
@@ -136,16 +136,16 @@ impl Router {
 
     // Tests for a match by adding or removing a trailing slash.
     fn redirect_slash(&self, req : &Request) -> Option<IronError> {
-        let mut url = req.url.clone();
-        let mut path = url.path.join("/");
+        let url = req.url.clone();
+        let mut path = url.path().join("/");
 
         if let Some(last_char) = path.chars().last() {
             if last_char == '/' {
                 path.pop();
-                url.path.pop();
+                url.path().pop();
             } else {
                 path.push('/');
-                url.path.push(String::new());
+                url.path().push(&String::new());
             }
         }
 
@@ -167,7 +167,7 @@ impl Key for Router { type Value = Params; }
 
 impl Handler for Router {
     fn handle(&self, req: &mut Request) -> IronResult<Response> {
-        let path = req.url.path.join("/");
+        let path = req.url.path().join("/");
 
         self.handle_method(req, &path).unwrap_or_else(||
             match req.method {


### PR DESCRIPTION
Makes `router` play nice with Iron.

According to semver this needs a version bump. Also should require a re-deploy to crates.io.

Tests are green, but 3/4 are ignored. Examples work.