### PR TITLE
(doc) Create struct_handler.rs

### DIFF
--- a/examples/struct_handler.rs
+++ b/examples/struct_handler.rs
@@ -1,4 +1,5 @@
 extern crate iron;
+extern crate router;
 
 use iron::Handler;
 use iron::status;
@@ -6,6 +7,7 @@ use iron::IronResult;
 use iron::Response;
 use iron::Request;
 use iron::Iron;
+use router::Router;
 
 struct MessageHandler {
     message: String
@@ -18,12 +20,12 @@ impl Handler for MessageHandler {
 }
 
 fn main() {
-    let echo = MessageHandler {
+    let handler = MessageHandler {
         message: "You've found the index page!".to_string()
     };
 
     let mut router = Router::new();
-    router.get("/", echo, "index");
+    router.get("/", handler, "index");
 
     Iron::new(router).http("localhost:3000").unwrap();
 }

--- a/examples/struct_handler.rs
+++ b/examples/struct_handler.rs
@@ -1,0 +1,29 @@
+extern crate iron;
+
+use iron::Handler;
+use iron::status;
+use iron::IronResult;
+use iron::Response;
+use iron::Request;
+use iron::Iron;
+
+struct MessageHandler {
+    message: String
+}
+
+impl Handler for MessageHandler {
+    fn handle(&self, _: &mut Request) -> IronResult<Response> {
+        Ok(Response::with((status::Ok, self.message.clone())))
+    }
+}
+
+fn main() {
+    let echo = MessageHandler {
+        message: "You've found the index page!".to_string()
+    };
+
+    let mut router = Router::new();
+    router.get("/", echo, "index");
+
+    Iron::new(router).http("localhost:3000").unwrap();
+}


### PR DESCRIPTION
In response to needing more documentation, create a routing example that doesn't rely on functions that can be statically compiled.

Original code from https://github.com/iron/iron/pull/491, moved to the router repository.