### PR TITLE
remove warning: this pattern creates a reference to a reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ fn main() {
     Iron::new(router).http("localhost:3000").unwrap();
 
     fn handler(req: &mut Request) -> IronResult<Response> {
-        let ref query = req.extensions.get::<Router>().unwrap().find("query").unwrap_or("/");
-        Ok(Response::with((status::Ok, *query)))
+        let query = req.extensions.get::<Router>().unwrap().find("query").unwrap_or("/");
+        Ok(Response::with((status::Ok, query)))
     }
 }
 ```


### PR DESCRIPTION
[clippy](https://github.com/rust-lang-nursery/rust-clippy) complains with the current example code. ;)