### PR TITLE
Changes for the upcoming iron 0.7 release with hyper 0.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 name = "router"
 authors = ["Jonathan Reem <jonathan.reem@gmail.com>"]
 license = "MIT"
-version = "0.6.0"
+version = "0.7.0-pre1"
 description = "A router for the Iron framework."
 repository = "https://github.com/iron/router"
 documentation = "http://ironframework.io/doc/router/index.html"
@@ -11,5 +11,5 @@ keywords = ["iron", "web", "http", "routing", "router"]
 
 [dependencies]
 route-recognizer = "0.1"
-iron = "0.6"
+iron = { git = "https://github.com/iron/iron", branch = "master" }
 url = "1.1"

--- a/examples/custom_404.rs
+++ b/examples/custom_404.rs
@@ -5,9 +5,8 @@ extern crate router;
 // To use, go to http://localhost:3000/foobar to see the custom 404
 // Or, go to http://localhost:3000 for a standard 200 OK
 
-use iron::{Iron, Request, Response, IronResult, AfterMiddleware, Chain};
+use iron::{Iron, Request, Response, IronResult, AfterMiddleware, Chain, StatusCode};
 use iron::error::{IronError};
-use iron::status;
 use router::{Router, NoRoute};
 
 struct Custom404;
@@ -17,7 +16,7 @@ impl AfterMiddleware for Custom404 {
         println!("Hitting custom 404 middleware");
 
         if err.error.is::<NoRoute>() {
-            Ok(Response::with((status::NotFound, "Custom 404 response")))
+            Ok(Response::with((StatusCode::NOT_FOUND, "Custom 404 response")))
         } else {
             Err(err)
         }
@@ -31,9 +30,9 @@ fn main() {
     let mut chain = Chain::new(router);
     chain.link_after(Custom404);
 
-    Iron::new(chain).http("localhost:3000").unwrap();
+    Iron::new(chain).http("localhost:3000");
 }
 
 fn handler(_: &mut Request) -> IronResult<Response> {
-    Ok(Response::with((status::Ok, "Handling response")))
+    Ok(Response::with((StatusCode::OK, "Handling response")))
 }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -5,8 +5,7 @@ extern crate router;
 // To use, go to http://localhost:3000/test and see output "test"
 // Or, go to http://localhost:3000 to see a default "OK"
 
-use iron::{Iron, Request, Response, IronResult};
-use iron::status;
+use iron::{Iron, Request, Response, IronResult, StatusCode};
 use router::{Router};
 
 fn main() {
@@ -14,16 +13,16 @@ fn main() {
     router.get("/", handler, "handler");
     router.get("/:query", query_handler, "query_handler");
 
-    Iron::new(router).http("localhost:3000").unwrap();
+    Iron::new(router).http("localhost:3000");
 
     fn handler(_: &mut Request) -> IronResult<Response> {
-        Ok(Response::with((status::Ok, "OK")))
+        Ok(Response::with((StatusCode::OK, "OK")))
     }
 
     fn query_handler(req: &mut Request) -> IronResult<Response> {
         let ref query = req.extensions.get::<Router>()
             .unwrap().find("query").unwrap_or("/");
-        Ok(Response::with((status::Ok, *query)))
+        Ok(Response::with((StatusCode::OK, *query)))
     }
 
 

--- a/examples/simple_with_macro.rs
+++ b/examples/simple_with_macro.rs
@@ -6,22 +6,21 @@ extern crate router;
 // To use, go to http://localhost:3000/test and see output "test"
 // Or, go to http://localhost:3000 to see a default "OK"
 
-use iron::{Iron, Request, Response, IronResult};
-use iron::status;
+use iron::{Iron, Request, Response, IronResult, StatusCode};
 use router::{Router};
 
 fn main() {
     let router = router!(root: get "/" => handler, query: get "/:query" => query_handler);
 
-    Iron::new(router).http("localhost:3000").unwrap();
+    Iron::new(router).http("localhost:3000");
 
     fn handler(_: &mut Request) -> IronResult<Response> {
-        Ok(Response::with((status::Ok, "OK")))
+        Ok(Response::with((StatusCode::OK, "OK")))
     }
 
     fn query_handler(req: &mut Request) -> IronResult<Response> {
         let ref query = req.extensions.get::<Router>()
             .unwrap().find("query").unwrap_or("/");
-        Ok(Response::with((status::Ok, *query)))
+        Ok(Response::with((StatusCode::OK, *query)))
     }
 }

--- a/examples/struct_handler.rs
+++ b/examples/struct_handler.rs
@@ -1,12 +1,7 @@
 extern crate iron;
 extern crate router;
 
-use iron::Handler;
-use iron::status;
-use iron::IronResult;
-use iron::Response;
-use iron::Request;
-use iron::Iron;
+use iron::{Handler, StatusCode, IronResult, Response, Request, Iron};
 use router::Router;
 
 struct MessageHandler {
@@ -15,7 +10,7 @@ struct MessageHandler {
 
 impl Handler for MessageHandler {
     fn handle(&self, _: &mut Request) -> IronResult<Response> {
-        Ok(Response::with((status::Ok, self.message.clone())))
+        Ok(Response::with((StatusCode::OK, self.message.clone())))
     }
 }
 
@@ -27,5 +22,5 @@ fn main() {
     let mut router = Router::new();
     router.get("/", handler, "index");
 
-    Iron::new(router).http("localhost:3000").unwrap();
+    Iron::new(router).http("localhost:3000");
 }

--- a/examples/url_for.rs
+++ b/examples/url_for.rs
@@ -8,7 +8,7 @@ extern crate iron;
 // Go to http://localhost:3000/foo to see "foo".
 
 use iron::prelude::*;
-use iron::status;
+use iron::StatusCode;
 use router::Router;
 
 fn main() {
@@ -17,11 +17,11 @@ fn main() {
         id_2: get "/:query" => query_handler
     };
 
-    Iron::new(router).http("localhost:3000").unwrap();
+    Iron::new(router).http("localhost:3000");
 
     fn handler(r: &mut Request) -> IronResult<Response> {
         Ok(Response::with((
-            status::Ok,
+            StatusCode::OK,
             format!("Please go to: {}",
                     url_for!(r, "id_2",
                              "query" => "test",
@@ -32,7 +32,7 @@ fn main() {
     fn query_handler(req: &mut Request) -> IronResult<Response> {
         let ref query = req.extensions.get::<Router>()
             .unwrap().find("query").unwrap_or("/");
-        Ok(Response::with((status::Ok, *query)))
+        Ok(Response::with((StatusCode::OK, *query)))
     }
 
 


### PR DESCRIPTION
This PR contains all changes necessary to work together with https://github.com/iron/iron after https://github.com/iron/iron/pull/523

This is mostly changes of type names and value names due to changes in the https://github.com/hyperium/http crate.